### PR TITLE
Fix bug where in VS2017, language services do not light up if the projected file is not open before ToolWindow comes up

### DIFF
--- a/ProjectionBufferTutorial/ProjBufferToolWindow.cs
+++ b/ProjectionBufferTutorial/ProjBufferToolWindow.cs
@@ -62,10 +62,30 @@ namespace ProjectionBufferTutorial
                 , dwFlags: (uint)_EDITORREGFLAGS.RIEF_ENABLECACHING
                 , pFactory: null
                 , ppEditor: out invisibleEditor));
-
+            RegisterDocument(filePath);
             return invisibleEditor;
         }
+		
+        uint RegisterDocument(string targetFile)
+        {
+            //Then when creating the IVsInvisibleEditor, find and lock the document 
+            uint itemID;
+            IntPtr docData;
+            uint docCookie;
+            IVsHierarchy hierarchy;
+            var runningDocTable = (IVsRunningDocumentTable)Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(SVsRunningDocumentTable));
 
+            ErrorHandler.ThrowOnFailure(runningDocTable.FindAndLockDocument(
+                dwRDTLockType: (uint) _VSRDTFLAGS.RDT_EditLock,
+                pszMkDocument: targetFile,
+                ppHier: out hierarchy,
+                pitemid: out itemID,
+                ppunkDocData: out docData,
+                pdwCookie: out docCookie));
+
+            return docCookie;
+        }
+		
         public IWpfTextViewHost CreateEditor(string filePath, int start = 0, int end = 0, bool createProjectedEditor = false)
         {
             //IVsInvisibleEditors are in-memory represenations of typical Visual Studio editors.


### PR DESCRIPTION
When this bug occurs, the syntax highlighting within the ToolWindow either doesn't show up at all, or does appear for a moment and then disappear within a couple of seconds after the ToolWindow is opened.

The fix is to register the document in Visual Studio's Running Documents Table.